### PR TITLE
Version-lock CentOS 7.5 kernel to 3.10.0-862.9.1

### DIFF
--- a/centos-lustre-templates/centos-7.5/centos75-1804-base-packerfile.json
+++ b/centos-lustre-templates/centos-7.5/centos75-1804-base-packerfile.json
@@ -1,49 +1,48 @@
 {
-	"_comment": "Packer description for a minimal CentOS Server provides basis for creating Lustre servers and clients (compute nodes)",
-	"variables": {
-		"account_name": "",
-		"box_name": "",
-		"version": ""
-	},
+  "_comment": "Packer description for a minimal CentOS Server provides basis for creating Lustre servers and clients (compute nodes)",
+  "variables": {
+    "account_name": "",
+    "box_name": "",
+    "version": ""
+  },
 
-	"builders": [
-		{
-			"vm_name": "CentOS-75-base",
-			"type": "virtualbox-iso",
-			"guest_os_type": "RedHat_64",
-			"hard_drive_interface": "sata",
-			"iso_url":
-				"https://mirrors.edge.kernel.org/centos/7.5.1804/isos/x86_64/CentOS-7-x86_64-DVD-1804.iso",
-			"iso_checksum_url": "https://mirrors.edge.kernel.org/centos/7.5.1804/isos/x86_64/sha256sum.txt.asc",
-			"iso_checksum_type": "sha256",
-			"guest_additions_mode": "disable",
-			"headless": true,
-			"ssh_username": "vagrant",
-			"ssh_password": "vagrant",
-			"ssh_timeout": "35m",
-			"post_shutdown_delay": "15s",
-			"http_directory" : "../httpfiles",
-			"boot_command": [
-				"<tab><wait>",
-				" ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/kickstart/base_el7_5.ks",
-				"<enter>"
-			],
-			"shutdown_command": "sudo shutdown --poweroff now"
-		}
-	],
+  "builders": [
+    {
+      "vm_name": "CentOS-75-base",
+      "type": "virtualbox-iso",
+      "guest_os_type": "RedHat_64",
+      "hard_drive_interface": "sata",
+      "iso_url": "https://mirrors.edge.kernel.org/centos/7.5.1804/isos/x86_64/CentOS-7-x86_64-DVD-1804.iso",
+      "iso_checksum_url": "https://mirrors.edge.kernel.org/centos/7.5.1804/isos/x86_64/sha256sum.txt.asc",
+      "iso_checksum_type": "sha256",
+      "guest_additions_mode": "disable",
+      "headless": true,
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_timeout": "35m",
+      "post_shutdown_delay": "15s",
+      "http_directory": "../httpfiles",
+      "boot_command": [
+        "<tab><wait>",
+        " ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/kickstart/base_el7_5.ks",
+        "<enter>"
+      ],
+      "shutdown_command": "sudo shutdown --poweroff now"
+    }
+  ],
 
-	"post-processors": [
-		[
-			{
-				"type": "vagrant",
-				"vagrantfile_template": "../Vagrantfile",
-				"keep_input_artifact": false
-			},
-			{
-				"type": "vagrant-cloud",
-				"box_tag": "{{ user `account_name` }}/{{ user `box_name` }}",
-				"version": "{{user `version`}}"
-			}
-		]
-	]
+  "post-processors": [
+    [
+      {
+        "type": "vagrant",
+        "vagrantfile_template": "../Vagrantfile",
+        "keep_input_artifact": false
+      },
+      {
+        "type": "vagrant-cloud",
+        "box_tag": "{{ user `account_name` }}/{{ user `box_name` }}",
+        "version": "{{user `version`}}"
+      }
+    ]
+  ]
 }

--- a/centos-lustre-templates/httpfiles/kickstart/base_el7_5.ks
+++ b/centos-lustre-templates/httpfiles/kickstart/base_el7_5.ks
@@ -38,12 +38,12 @@ selinux --disabled
 
 %post
 # Versionlock kernel-headers
-wget http://mirror.centos.org/centos/7.5.1804/updates/x86_64/Packages/kernel-3.10.0-862.2.3.el7.x86_64.rpm
-wget http://mirror.centos.org/centos/7.5.1804/updates/x86_64/Packages/kernel-devel-3.10.0-862.2.3.el7.x86_64.rpm
-wget http://mirror.centos.org/centos/7.5.1804/updates/x86_64/Packages/kernel-headers-3.10.0-862.2.3.el7.x86_64.rpm
+wget http://mirror.centos.org/centos/7.5.1804/updates/x86_64/Packages/kernel-3.10.0-862.9.1.el7.x86_64.rpm
+wget http://mirror.centos.org/centos/7.5.1804/updates/x86_64/Packages/kernel-devel-3.10.0-862.9.1.el7.x86_64.rpm
+wget http://mirror.centos.org/centos/7.5.1804/updates/x86_64/Packages/kernel-headers-3.10.0-862.9.1.el7.x86_64.rpm
 yum -y install yum-plugin-versionlock
-yum install -y kernel-3.10.0-862.2.3.el7.x86_64.rpm kernel-devel-3.10.0-862.2.3.el7.x86_64.rpm kernel-headers-3.10.0-862.2.3.el7.x86_64.rpm
-yum versionlock kernel-headers-3.10.0-862.2.3.el7.x86_64
+yum install -y kernel-3.10.0-862.9.1.el7.x86_64.rpm kernel-devel-3.10.0-862.9.1.el7.x86_64.rpm kernel-headers-3.10.0-862.9.1.el7.x86_64.rpm
+yum versionlock kernel-headers-3.10.0-862.9.1.el7.x86_64
 # Download the default public key for the vagrant user from the 
 # Vagrant GitHub project. Used by all public base boxes for first
 # time boot.


### PR DESCRIPTION
Bump to 3.10.0-862.9.1 to reflect current 2.10.5 lustre.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>